### PR TITLE
Add run_on option to specify when to run the rocco command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ It's a [Guard](http://github.com/guard/guard) for the [Rocco](http://github.com/
 
 ``` ruby
 # default values
-guard 'rocco', :run_all => [:start, :change], :dir => 'doc', :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css' do
+guard 'rocco', :run_on => [:start, :change], :dir => 'doc', :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css' do
   watch(%r{^app/.*\.(rb|coffee)$})
   watch(%r{^lib/.*\.rb$})
 end

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 It's a [Guard](http://github.com/guard/guard) for the [Rocco](http://github.com/rtomayko/rocco) documentation system!
 
-    guard 'rocco' do
-      watch(%r{^app/.*\.(rb|coffee)$})
-      watch(%r{^lib/.*\.rb$})
-    end
-
+``` ruby
+# default values
+guard 'rocco', :run_all => [:start, :change], :dir => 'doc', :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css' do
+  watch(%r{^app/.*\.(rb|coffee)$})
+  watch(%r{^lib/.*\.rb$})
+end
+```
 Options:
 
-* `:dir` specifies the output dir (default `doc`)
-* `:stylesheet` specifies a custom stylesheet to use (default is
-  http://jashkenas.github.com/docco/resources/docco.css)
+* `:run_on` specifies when to update the docs
+  * `:start` - run on all documentation when the guard starts
+  * `:change` - run when watched files change
+  * `:reload` - run when the guard is reloaded
+  * `:all` - run when running all the guards
+* `:dir` specifies the output dir
+* `:stylesheet` specifies a custom stylesheet to use
 
 `gem install guard-rocco` or Bundle it up with `gem 'guard-rocco'`. Then `guard init rocco`. Yeah!
 

--- a/lib/guard/rocco/templates/Guardfile
+++ b/lib/guard/rocco/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'rocco', :run_all => [:start, :change], :dir => 'doc', :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css' do
+guard 'rocco' do
   # For Rails 3.0.x and 3.1
   watch(%r{^app/.*\.(rb|coffee)$})
   watch(%r{^lib/.*\.rb$})

--- a/lib/guard/rocco/templates/Guardfile
+++ b/lib/guard/rocco/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'rocco' do
+guard 'rocco', :run_all => [:start, :change], :dir => 'doc', :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css' do
   # For Rails 3.0.x and 3.1
   watch(%r{^app/.*\.(rb|coffee)$})
   watch(%r{^lib/.*\.rb$})

--- a/spec/lib/guard/rocco_spec.rb
+++ b/spec/lib/guard/rocco_spec.rb
@@ -36,5 +36,19 @@ describe Guard::Rocco do
       File.file?(File.join(doc_dir, 'lib/guard/rocco.html')).should be_true
     end
   end
+  
+  describe 'run options' do
+    it 'should allow array of symbols' do
+      guard = Guard::Rocco.new([], :run_on => [:start, :change])
+      guard.run_for?(:start).should be_true
+      guard.run_for?(:reload).should be_false
+    end
+
+    it 'should allow symbol' do
+      guard = Guard::RailsAssets.new([], :run_on => :start)
+      guard.run_for?(:start).should be_true
+      guard.run_for?(:reload).should be_false
+    end
+  end
 end
 


### PR DESCRIPTION
It's a [Guard](http://github.com/guard/guard) for the [Rocco](http://github.com/rtomayko/rocco) documentation system!

``` ruby
# default values
guard 'rocco', :run_on => [:start, :change], :dir => 'doc', :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css' do
  watch(%r{^app/.*\.(rb|coffee)$})
  watch(%r{^lib/.*\.rb$})
end
```

Options:
- `:run_on` specifies when to update the docs
  - `:start` - run on all documentation when the guard starts
  - `:change` - run when watched files change
  - `:reload` - run when the guard is reloaded
  - `:all` - run when running all the guards
- `:dir` specifies the output dir
- `:stylesheet` specifies a custom stylesheet to use

`gem install guard-rocco` or Bundle it up with `gem 'guard-rocco'`. Then `guard init rocco`. Yeah!
